### PR TITLE
Implement constraints for Facility fields and add related tests

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -60,10 +60,14 @@ public class ParserUtil {
      *
      * @param name String to be parsed.
      * @return FacilityName object with specified name.
+     * @throws ParseException if given facility name is invalid.
      */
-    public static FacilityName parseFacilityName(String name) {
+    public static FacilityName parseFacilityName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
+        if (!FacilityName.isValidFacilityName(trimmedName)) {
+            throw new ParseException(FacilityName.MESSAGE_CONSTRAINTS);
+        }
         return new FacilityName(trimmedName);
     }
 
@@ -73,10 +77,14 @@ public class ParserUtil {
      *
      * @param location String to be parsed.
      * @return Location object with specified value.
+     * @throws ParseException if given location is invalid.
      */
-    public static Location parseLocation(String location) {
+    public static Location parseLocation(String location) throws ParseException {
         requireNonNull(location);
         String trimmedLocation = location.trim();
+        if (!Location.isValidLocation(trimmedLocation)) {
+            throw new ParseException(Location.MESSAGE_CONSTRAINTS);
+        }
         return new Location(trimmedLocation);
     }
 
@@ -86,10 +94,14 @@ public class ParserUtil {
      *
      * @param time String to be parsed.
      * @return Time object with specified value.
+     * @throws ParseException if the given time is invalid.
      */
-    public static Time parseTime(String time) {
+    public static Time parseTime(String time) throws ParseException {
         requireNonNull(time);
         String trimmedTime = time.trim();
+        if (!Time.isValidTime(trimmedTime)) {
+            throw new ParseException(Time.MESSAGE_CONSTRAINTS);
+        }
         return new Time(trimmedTime);
     }
 
@@ -99,10 +111,14 @@ public class ParserUtil {
      *
      * @param capacity String to be parsed.
      * @return Capacity object with specified value.
+     * @throws ParseException if given capacity is invalid.
      */
-    public static Capacity parseCapacity(String capacity) {
+    public static Capacity parseCapacity(String capacity) throws ParseException {
         requireNonNull(capacity);
         String trimmedCapacity = capacity.trim();
+        if (!Capacity.isValidCapacity(trimmedCapacity)) {
+            throw new ParseException(Capacity.MESSAGE_CONSTRAINTS);
+        }
         return new Capacity(trimmedCapacity);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -44,11 +44,11 @@ public class CommandTestUtil {
 
     public static final String VALID_FACILITY_NAME_COURT = "Court 1";
     public static final String VALID_LOCATION_COURT = "University Sports Hall";
-    public static final String VALID_TIME_COURT = "11:30";
+    public static final String VALID_TIME_COURT = "1130";
     public static final String VALID_CAPACITY_COURT = "5";
     public static final String VALID_FACILITY_NAME_FIELD = "NUS Field 2";
     public static final String VALID_LOCATION_FIELD = "Opp University Hall";
-    public static final String VALID_TIME_FIELD = "13:30";
+    public static final String VALID_TIME_FIELD = "1330";
     public static final String VALID_CAPACITY_FIELD = "8";
 
     public static final String NAME_DESC_COURT = " " + PREFIX_NAME + VALID_FACILITY_NAME_COURT;

--- a/src/test/java/seedu/address/logic/parser/AddFacilityCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddFacilityCommandParserTest.java
@@ -32,7 +32,7 @@ class AddFacilityCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         Facility facility = new Facility(new FacilityName("Court 1"), new Location("University Sports Hall"),
-                new Time("11:30"), new Capacity("5"));
+                new Time("1130"), new Capacity("5"));
 
         assertParseSuccess(parser, NAME_DESC_COURT + LOCATION_DESC_COURT + TIME_DESC_COURT + CAPACITY_DESC_COURT,
                 new AddFacilityCommand(facility));
@@ -58,7 +58,7 @@ class AddFacilityCommandParserTest {
     @Test
     public void parse_fieldsMissing_exceptionThrown() {
         Facility facility = new Facility(new FacilityName("Court 1"), new Location("University Sports Hall"),
-                new Time("11:30"), new Capacity("5"));
+                new Time("1130"), new Capacity("5"));
 
         //missing name
         assertParseFailure(parser, LOCATION_DESC_COURT + TIME_DESC_COURT + CAPACITY_DESC_COURT,

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -59,7 +59,7 @@ public class AddressBookParserTest {
         Capacity capacity = new Capacity("5");
         Facility facility = new Facility(name, location, time, capacity);
         AddFacilityCommand command = (AddFacilityCommand) parser.parseCommand("addf "
-                + "n/Court 1 l/University Sports Hall t/11:30 c/5");
+                + "n/Court 1 l/University Sports Hall t/1130 c/5");
         assertEquals(new AddFacilityCommand(facility), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -55,7 +55,7 @@ public class AddressBookParserTest {
     public void parseCommand_addFacility() throws ParseException {
         FacilityName name = new FacilityName("Court 1");
         Location location = new Location("University Sports Hall");
-        Time time = new Time("11:30");
+        Time time = new Time("1130");
         Capacity capacity = new Capacity("5");
         Facility facility = new Facility(name, location, time, capacity);
         AddFacilityCommand command = (AddFacilityCommand) parser.parseCommand("addf "

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -38,10 +38,15 @@ public class ParserUtilTest {
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 
-    private static final String FACILITY_NAME = "Court";
-    private static final String FACILITY_LOCATION = "University Hall";
-    private static final String FACILITY_TIME = "11:30";
-    private static final String FACILITY_CAPACITY = "5";
+    private static final String INVALID_FACILITY_NAME = "Cour+";
+    private static final String INVALID_FACILITY_LOCATION = "University H@ll";
+    private static final String INVALID_FACILITY_TIME = "555";
+    private static final String INVALID_FACILITY_CAPACITY = "Z";
+
+    private static final String VALID_FACILITY_NAME = "Court";
+    private static final String VALID_FACILITY_LOCATION = "University Hall";
+    private static final String VALID_FACILITY_TIME = "1130";
+    private static final String VALID_FACILITY_CAPACITY = "5";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -71,15 +76,20 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseFacilityName_valueWithoutWhiteSpace_returnsFacilityName() {
-        FacilityName name = new FacilityName(FACILITY_NAME);
-        assertEquals(name, ParserUtil.parseFacilityName(FACILITY_NAME));
+    public void parseFacilityName_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseFacilityName(INVALID_FACILITY_NAME));
     }
 
     @Test
-    public void parseFacilityName_valueWithWhiteSpace_returnsTrimmedName() {
-        FacilityName name = new FacilityName(FACILITY_NAME);
-        assertEquals(name, ParserUtil.parseFacilityName(WHITESPACE + FACILITY_NAME + WHITESPACE));
+    public void parseFacilityName_valueWithoutWhiteSpace_returnsFacilityName() throws Exception {
+        FacilityName name = new FacilityName(VALID_FACILITY_NAME);
+        assertEquals(name, ParserUtil.parseFacilityName(VALID_FACILITY_NAME));
+    }
+
+    @Test
+    public void parseFacilityName_valueWithWhiteSpace_returnsTrimmedName() throws Exception {
+        FacilityName name = new FacilityName(VALID_FACILITY_NAME);
+        assertEquals(name, ParserUtil.parseFacilityName(WHITESPACE + VALID_FACILITY_NAME + WHITESPACE));
     }
 
     @Test
@@ -88,15 +98,20 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseLocation_valueWithoutWhiteSpace_returnsLocation() {
-        Location location = new Location(FACILITY_LOCATION);
-        assertEquals(location, ParserUtil.parseLocation(FACILITY_LOCATION));
+    public void parseLocation_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseLocation(INVALID_FACILITY_LOCATION));
     }
 
     @Test
-    public void parseLocation_valueWithWhiteSpace_returnsTrimmedLocation() {
-        Location location = new Location(FACILITY_LOCATION);
-        assertEquals(location, ParserUtil.parseLocation(WHITESPACE + FACILITY_LOCATION + WHITESPACE));
+    public void parseLocation_valueWithoutWhiteSpace_returnsLocation() throws Exception {
+        Location location = new Location(VALID_FACILITY_LOCATION);
+        assertEquals(location, ParserUtil.parseLocation(VALID_FACILITY_LOCATION));
+    }
+
+    @Test
+    public void parseLocation_valueWithWhiteSpace_returnsTrimmedLocation() throws Exception {
+        Location location = new Location(VALID_FACILITY_LOCATION);
+        assertEquals(location, ParserUtil.parseLocation(WHITESPACE + VALID_FACILITY_LOCATION + WHITESPACE));
     }
 
     @Test
@@ -105,15 +120,20 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTime_valueWithoutWhiteSpace_returnsTime() {
-        Time time = new Time(FACILITY_TIME);
-        assertEquals(time, ParserUtil.parseTime(FACILITY_TIME));
+    public void parseTime_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTime(INVALID_FACILITY_TIME));
     }
 
     @Test
-    public void parseTime_valueWithWhiteSpace_returnsTrimmedTime() {
-        Time time = new Time(FACILITY_TIME);
-        assertEquals(time, ParserUtil.parseTime(WHITESPACE + FACILITY_TIME + WHITESPACE));
+    public void parseTime_valueWithoutWhiteSpace_returnsTime() throws Exception {
+        Time time = new Time(VALID_FACILITY_TIME);
+        assertEquals(time, ParserUtil.parseTime(VALID_FACILITY_TIME));
+    }
+
+    @Test
+    public void parseTime_valueWithWhiteSpace_returnsTrimmedTime() throws Exception {
+        Time time = new Time(VALID_FACILITY_TIME);
+        assertEquals(time, ParserUtil.parseTime(WHITESPACE + VALID_FACILITY_TIME + WHITESPACE));
     }
 
     @Test
@@ -122,16 +142,23 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseCapacity_valueWithoutWhiteSpace_returnsCapacity() {
-        Capacity capacity = new Capacity(FACILITY_CAPACITY);
-        assertEquals(capacity, ParserUtil.parseCapacity(FACILITY_CAPACITY));
+    public void parseCapacity_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCapacity(INVALID_FACILITY_CAPACITY));
     }
 
     @Test
-    public void parseLocation_valueWithWhiteSpace_returnsTrimmedCapacity() {
-        Capacity capacity = new Capacity(FACILITY_CAPACITY);
-        assertEquals(capacity, ParserUtil.parseCapacity(WHITESPACE + FACILITY_CAPACITY + WHITESPACE));
+    public void parseCapacity_valueWithoutWhiteSpace_returnsCapacity() throws Exception {
+        Capacity capacity = new Capacity(VALID_FACILITY_CAPACITY);
+        assertEquals(capacity, ParserUtil.parseCapacity(VALID_FACILITY_CAPACITY));
     }
+
+    @Test
+    public void parseCapacity_valueWithWhiteSpace_returnsTrimmedCapacity() throws Exception {
+        Capacity capacity = new Capacity(VALID_FACILITY_CAPACITY);
+        assertEquals(capacity, ParserUtil.parseCapacity(WHITESPACE + VALID_FACILITY_CAPACITY + WHITESPACE));
+    }
+
+
 
     @Test
     public void parseName_null_throwsNullPointerException() {


### PR DESCRIPTION
should merge this first
fixes #110 

Note that now facilities details have constraints and are listed below:

Facility name: alphanumeric and whitespaces only
Location: alphanumeric and whitespaces only
Time: exactly 4 digits only without ":"
Capacity: any number of digits only